### PR TITLE
Add shortcutsbench

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,10 @@ If you find our paper or code useful, please cite the paper:
 
 ### $\S6.1.2$ Aggregated API benchmarks
 
+- Collect App Intents (APIs) in real-world macOS/iPadOS/iOS.
+  
+  **ShortcutsBench: A Large-Scale Real-World Benchmark for API-Based Agents** *Shen, Haiyang, et al.* 2024.07 [[Paper]](https://arxiv.org/abs/2407.00132)
+
 - Collect RapidAPIs and use models to synthesize examples for evaluation
   
   **ToolLLM: Facilitating Large Language Models to Master 16000+ Real-world APIs** *Qin, Yujia, et al.* 2023.07 [[Paper]](https://openreview.net/forum?id=dHng2O0Jjr)
@@ -373,3 +377,9 @@ If you find our paper or code useful, please cite the paper:
 - Collect tools from Huggingface and PublicAPIs
   
   **Taskbench: Benchmarking large language models for task automation** *Shen, Yongliang, et al.* 2023.11 [[Paper]](https://openreview.net/forum?id=70xhiS0AQS&referrer=%5Bthe%20profile%20of%20Xu%20Tan%5D(%2Fprofile%3Fid%3D~Xu_Tan1))
+
+### $\S6.1.3$ Aggregated Actions Sequences benchmarks
+
+- Collect App Intents (APIs) in real-world macOS/iPadOS/iOS.
+  
+  **ShortcutsBench: A Large-Scale Real-World Benchmark for API-Based Agents** *Shen, Haiyang, et al.* 2024.07 [[Paper]](https://arxiv.org/abs/2407.00132)

--- a/README.md
+++ b/README.md
@@ -378,8 +378,8 @@ If you find our paper or code useful, please cite the paper:
   
   **Taskbench: Benchmarking large language models for task automation** *Shen, Yongliang, et al.* 2023.11 [[Paper]](https://openreview.net/forum?id=70xhiS0AQS&referrer=%5Bthe%20profile%20of%20Xu%20Tan%5D(%2Fprofile%3Fid%3D~Xu_Tan1))
 
-### $\S6.1.3$ Aggregated Actions Sequences benchmarks
+### $\S6.1.3$ Aggregated Action Sequences benchmarks
 
-- Collect App Intents (APIs) in real-world macOS/iPadOS/iOS.
+- Collect Action Sequences in real-world macOS/iPadOS/iOS.
   
   **ShortcutsBench: A Large-Scale Real-World Benchmark for API-Based Agents** *Shen, Haiyang, et al.* 2024.07 [[Paper]](https://arxiv.org/abs/2407.00132)

--- a/README.md
+++ b/README.md
@@ -346,10 +346,6 @@ If you find our paper or code useful, please cite the paper:
 
 ### $\S6.1.2$ Aggregated API benchmarks
 
-- Collect App Intents (APIs) in real-world macOS/iPadOS/iOS.
-  
-  **ShortcutsBench: A Large-Scale Real-World Benchmark for API-Based Agents** *Shen, Haiyang, et al.* 2024.07 [[Paper]](https://arxiv.org/abs/2407.00132)
-
 - Collect RapidAPIs and use models to synthesize examples for evaluation
   
   **ToolLLM: Facilitating Large Language Models to Master 16000+ Real-world APIs** *Qin, Yujia, et al.* 2023.07 [[Paper]](https://openreview.net/forum?id=dHng2O0Jjr)
@@ -377,8 +373,6 @@ If you find our paper or code useful, please cite the paper:
 - Collect tools from Huggingface and PublicAPIs
   
   **Taskbench: Benchmarking large language models for task automation** *Shen, Yongliang, et al.* 2023.11 [[Paper]](https://openreview.net/forum?id=70xhiS0AQS&referrer=%5Bthe%20profile%20of%20Xu%20Tan%5D(%2Fprofile%3Fid%3D~Xu_Tan1))
-
-### $\S6.1.3$ Aggregated Action Sequences benchmarks
 
 - Collect Action Sequences in real-world macOS/iPadOS/iOS.
   


### PR DESCRIPTION
We have added the paper *ShortcutsBench*, published on [arXiv](https://arxiv.org/pdf/2407.00132) in July 2024. 

You can access the dataset, processing code, experimental code, and results through the paper's [repo](https://github.com/eachsheep/shortcutsbench).